### PR TITLE
Remotely controllable validators with malicious modes

### DIFF
--- a/dist/src/index.js
+++ b/dist/src/index.js
@@ -383,7 +383,11 @@ class KYVE {
         const bundle = [];
         for (let height = fromHeight; height < toHeight; height++) {
             try {
-                bundle.push(await this.cache.get(height));
+                if (this.validatorMode == "ALWAYS_FAKE_VALID") {
+                    bundle.push(await this.cache.get(0));
+                } else {
+                    bundle.push(await this.cache.get(height));
+                }
             }
             catch {
                 break;
@@ -625,36 +629,35 @@ class KYVE {
         try {
             let voteMessage = "";
 
-            if (this.validatorMode == "NORMAL") {
-                if (vote === 0) {
-                    voteMessage = "valid";
-                }
-                else if (vote === 1) {
-                    voteMessage = "invalid";
-                }
-                else if (vote === 2) {
-                    voteMessage = "abstain";
-                }
-                else {
-                    throw Error(`Invalid vote: ${vote}`);
-                }
-            }
-
             if (this.validatorMode == "ALWAYS_VALID") {
-                voteMessage = "valid";
+                vote = 0;
             }
 
             if (this.validatorMode == "ALWAYS_FAKE_VALID") {
-                voteMessage = "valid";
+                vote = 0;
             }
 
             if (this.validatorMode == "ALWAYS_INVALID") {
-                voteMessage = "invalid";
+                vote = 1;
             }
 
             if (this.validatorMode == "ALWAYS_ABSTAIN") {
+                vote = 2;
+            }
+
+            if (vote === 0) {
+                voteMessage = "valid";
+            }
+            else if (vote === 1) {
+                voteMessage = "invalid";
+            }
+            else if (vote === 2) {
                 voteMessage = "abstain";
             }
+            else {
+                throw Error(`Invalid vote: ${vote}`);
+            }
+
             this.logger.debug(`Voting ${voteMessage} on bundle ${bundleId} ...`);
             const { transactionHash, transactionBroadcast } = await this.sdk.voteProposal(this.poolId, bundleId, vote);
             this.logger.debug(`Transaction = ${transactionHash}`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -120,7 +120,8 @@ class KYVE {
 
   async start() {
     // log node info
-    this.logger.info("Starting node ...");
+    this.logger.info("Starting node (SOLID POINT edition)...");
+
     console.log("");
     this.logger.info(`Name \t\t = ${this.name}`);
     this.logger.info(`Address \t\t = ${await this.wallet.getAddress()}`);
@@ -1106,8 +1107,8 @@ class KYVE {
         this.logger.info("Node is running as a validator.");
       }
     } else {
-      this.logger.error(`Node is not an active validator! Exiting ...`);
-      process.exit(1);
+      this.logger.error(`Node is not an active validator! We don't care...`);
+      // process.exit(1);
     }
   }
 


### PR DESCRIPTION
Validators support 5 modes:
- NORMAL - they act exactly like official validators
- ALWAYS_VALID - they vote "valid" no matter if bundle is correct or not.
- ALWAYS_FAKE_VALID - the same as ALWAYS_VALID, but if a validator is selected as Uploader, it will try to upload a fake bundle
- ALWAYS_INVALID - always vote "invalid"
- ALWAYS_ABSTAIN - always vote "abstain"

Modes are set by a remote control panel and can be changed on the fly.